### PR TITLE
Update to nom 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 
 [dependencies]
-nom = "~0.3.0"
+nom = "~1.0.0"
 
 [features]
 unstable = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,9 +72,9 @@ named!(object<Value>,
 named!(value<Value>,
        delimited!(opt!(space), alt!(number | boolean | string), opt!(space)));
 
-fn keyable<'a>(input: &'a [u8]) -> IResult<'a, &'a [u8], &[u8]> {
+fn keyable(input: &[u8]) -> IResult<&[u8], &[u8]> {
     if input.len() > 0 && !is_alphabetic(input[0]) {
-        return IResult::Error(nom::Err::Position(666, input));
+        return IResult::Error(nom::Err::Position(nom::ErrorKind::Custom(666), input));
     }
     for idx in 1..input.len() {
         if !is_alphanumeric(input[idx]) && input[idx] != b'_' && input[idx] != b'-' {


### PR DESCRIPTION
Hi!

nom 1.0 is here, and comes with a few breaking changes. To help the transition, and to test the beta version before release, I took the liberty to test and upgrade (if needed) your code to the 1.0 version. It should work right away, but if there are still issues, or if the code needs to be updated to your latest master, please let me know!

If you want an explanation of the changes, please take a look at the [upgrading documentation](https://github.com/Geal/nom/wiki/Upgrading-to-nom-1.0).

By the way, could you go to one (or all) of those links and write a few kind words about your experience writing parsers in Rust? It would really help me!
- [nom 1.0 release blogpost](https://www.clever-cloud.com/blog/engineering/2015/11/16/nom-1-0/)
- [Reddit post](https://www.reddit.com/r/rust/comments/3t10f3/nom_just_reached_10_cleaner_parsers_more_generic/)
- [Hacker News post](https://news.ycombinator.com/item?id=10574828)

Thank you for using nom!
